### PR TITLE
to .NET 4.5 and changed JSON serializer.

### DIFF
--- a/Source/Framework/Framework.csproj
+++ b/Source/Framework/Framework.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="MonoGame.Framework">
       <HintPath>..\..\..\..\..\Program Files (x86)\MonoGame\v3.0\Assemblies\DesktopGL\MonoGame.Framework.dll</HintPath>
     </Reference>

--- a/Source/Framework/Framework.csproj
+++ b/Source/Framework/Framework.csproj
@@ -1,17 +1,101 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C75E8EC6-FB61-4E7C-A51F-5ABB8BA3DBC4}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Lichen</RootNamespace>
+    <AssemblyName>Lichen</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
-
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <Compile Include="Class1.cs" />
+    <Compile Include="Entities\Component.cs" />
+    <Compile Include="Entities\Components\SpriteComponent.cs" />
+    <Compile Include="Entities\Components\TextComponent.cs" />
+    <Compile Include="Entities\Components\TilemapComponent.cs" />
+    <Compile Include="Entities\Entity.cs" />
+    <Compile Include="Entities\IRenderComponent.cs" />
+    <Compile Include="Entities\IUpdateComponent.cs" />
+    <Compile Include="Entities\UpdateChain.cs" />
+    <Compile Include="GlobalServices.cs" />
+    <Compile Include="Input\InputManager.cs" />
+    <Compile Include="Input\InputSetting.cs" />
+    <Compile Include="Input\InputType.cs" />
+    <Compile Include="Input\TextHandler.cs" />
+    <Compile Include="Libraries\Font.cs" />
+    <Compile Include="Libraries\FontLibrary.cs" />
+    <Compile Include="Libraries\Library.cs" />
+    <Compile Include="Libraries\SongLibrary.cs" />
+    <Compile Include="Libraries\SoundEffectLibrary.cs" />
+    <Compile Include="Libraries\Sprite.cs" />
+    <Compile Include="Libraries\SpriteLibrary.cs" />
+    <Compile Include="Libraries\TextureLibrary.cs" />
+    <Compile Include="Libraries\Tilemap.cs" />
+    <Compile Include="Libraries\TilemapLibrary.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Util\Console.cs" />
+    <Compile Include="Util\Delegate.cs" />
+    <Compile Include="Util\Error.cs" />
+    <Compile Include="Util\IPoolable.cs" />
+    <Compile Include="Util\JsonHelper.cs" />
+    <Compile Include="Util\MathHelper.cs" />
+    <Compile Include="Util\ObjectPool.cs" />
+    <Compile Include="Util\Pathfinder.cs" />
+    <Compile Include="Util\TextContainer.cs" />
+    <Compile Include="Util\XmlHelper.cs" />
   </ItemGroup>
-
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>12.0.1</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <!--
+    <Reference Include="System.Core"/>
+    <Reference Include="System.Xml.Linq"/>
+    <Reference Include="System.Data.DataSetExtensions"/>
+    <Reference Include="Microsoft.CSharp"/>
+    <Reference Include="System.Data"/>
+    <Reference Include="System.Net.Http"/>
+-->
     <Reference Include="MonoGame.Framework">
       <HintPath>..\..\..\..\..\Program Files (x86)\MonoGame\v3.0\Assemblies\DesktopGL\MonoGame.Framework.dll</HintPath>
     </Reference>
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
-
+  <!--
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+-->
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Source/Framework/Input/InputManager.cs
+++ b/Source/Framework/Input/InputManager.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Microsoft.Xna.Framework.Input;
+using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -8,12 +10,13 @@ using System.Xml.Serialization;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework.Input;
 
 namespace Lichen.Input
 {
+    [JsonObject]
     public class InputConfig
     {
+        [JsonProperty]
         public List<InputNode> InputNodes { get; set; }
 
         public InputConfig()
@@ -89,6 +92,7 @@ namespace Lichen.Input
             InputConfig inputConfig = Util.JsonHelper<InputConfig>.Load(path);
             foreach (InputNode inputNode in inputConfig.InputNodes)
             {
+                inputNode.PostSet();
                 inputNodeList[(int)inputNode.GameCommand] = inputNode;
             }
             Reset();
@@ -102,6 +106,7 @@ namespace Lichen.Input
                 // Hacky way to prevent certain keys from being written to the XML file (so users don't change them).
                 if ((int)command >= (int)GameCommand.MenuUp) continue;
 
+                inputNodeList[(int)command].PreGet();
                 inputConfig.InputNodes.Add(inputNodeList[(int)command]);
             }
             Util.JsonHelper<InputConfig>.Save(path, inputConfig);

--- a/Source/Framework/Input/InputSetting.cs
+++ b/Source/Framework/Input/InputSetting.cs
@@ -1,27 +1,17 @@
-﻿using System;
+﻿using Microsoft.Xna.Framework.Input;
+using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Serialization;
 using System.Text;
-using System.Threading.Tasks;
-using System.Xml.Serialization;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Content;
-using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework.Input;
 
 namespace Lichen.Input
 {
-    //[DataContract]
     public class UniversalInputCombo
     {
         List<UniversalInput> inputList;
         bool invalidPress;
 
-        //public List<UniversalInput> InputList { get { return inputList; } set { inputList = value; } }
-
-        [XmlAttribute]
-        //[DataMember]
         public string Value { get { return ToString(); } set { FromString(value); } }
 
         public UniversalInputCombo()
@@ -181,7 +171,7 @@ namespace Lichen.Input
         }
     }
 
-    [DataContract]
+    [JsonObject]
     public class InputNode
     {
         GameCommand gameCommand;
@@ -193,11 +183,10 @@ namespace Lichen.Input
         int tickCount;
         float heldTime;
 
-        [XmlIgnore]
+        [JsonIgnore]
         public GameCommand GameCommand { get { return gameCommand; } set { gameCommand = value; } }
 
-        [XmlAttribute]
-        [DataMember]
+        [JsonProperty]
         public string Command
         {
             get
@@ -212,9 +201,11 @@ namespace Lichen.Input
             }
         }
 
-        //        public List<UniversalInputCombo> InputCombos { get { return inputCombos; } set { inputCombos = value; } }
+        //public List<UniversalInputCombo> InputCombos { get { return inputCombos; } set { inputCombos = value; } }
 
-        [DataMember]
+        [JsonProperty]
+        public List<string> InputCombos { get; set; }
+        /*
         public List<string> InputCombos {
             get
             {
@@ -232,6 +223,26 @@ namespace Lichen.Input
                 {
                     inputCombos.Add(new UniversalInputCombo() { Value = ic });
                 }
+            }
+        }
+        */
+
+        public void PreGet()
+        {
+            List<string> ic = new List<string>();
+            foreach (UniversalInputCombo uic in inputCombos)
+            {
+                ic.Add(uic.Value);
+            }
+            InputCombos = ic;
+        }
+
+        public void PostSet()
+        {
+            inputCombos = new List<UniversalInputCombo>();
+            foreach (string ic in InputCombos)
+            {
+                inputCombos.Add(new UniversalInputCombo() { Value = ic });
             }
         }
 

--- a/Source/Framework/Libraries/Font.cs
+++ b/Source/Framework/Libraries/Font.cs
@@ -1,29 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
-using System.Xml.Serialization;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Content;
+﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework.Input;
+using Newtonsoft.Json;
 
 namespace Lichen.Libraries
 {
-    //[Serializable]
-    //[XmlRootAttribute("XnaContent", Namespace = "Microsoft.Xna.Framework", IsNullable = false)]
-    [DataContract]
+    [JsonObject]
     public class Font
     {
-        [DataMember]
+        [JsonProperty]
         public string FontFile { get; set; }
-        [DataMember]
+        [JsonProperty]
         public float Scale { get; set; }
 
         SpriteFont spriteFont;
-        [XmlIgnore]
+        [JsonIgnore]
         public SpriteFont SpriteFont { get { return spriteFont; } set { spriteFont = value; } }
 
         public Font()

--- a/Source/Framework/Libraries/Sprite.cs
+++ b/Source/Framework/Libraries/Sprite.cs
@@ -1,15 +1,9 @@
-﻿using System;
+﻿using Lichen.Util;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
-using System.Xml.Serialization;
-using Lichen.Util;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Content;
-using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework.Input;
 
 namespace Lichen.Libraries
 {
@@ -75,14 +69,14 @@ namespace Lichen.Libraries
         public List<Frame> Frames { get; set; }
     }
 
-    [DataContract]
+    [JsonObject]
     public class _Sprite
     {
-        [DataMember]
+        [JsonProperty]
         public _FrameRange DefaultFrame { get; set; }
-        [DataMember]
+        [JsonProperty]
         public string DefaultAnimation { get; set; }
-        [DataMember]
+        [JsonProperty]
         public List<_Animation> Animations { get; set; }
 
         public void Finalize(TextureLibrary textureLibrary, Pathfinder defaultPath)
@@ -170,28 +164,29 @@ namespace Lichen.Libraries
         }
     }
 
-    [DataContract]
+    [JsonObject]
     public class _FrameRange
     {
-        [DataMember]
+        [JsonProperty]
         public string Spritesheet { get; set; }
-        [DataMember]
+        [JsonProperty]
         public int? X { get; set; }
-        [DataMember]
+        [JsonProperty]
         public int? Y { get; set; }
-        [DataMember]
+        [JsonProperty]
         public int? Width { get; set; }
-        [DataMember]
+        [JsonProperty]
         public int? Height { get; set; }
-        [DataMember]
+        [JsonProperty]
         public float? AnchorX { get; set; }
-        [DataMember]
+        [JsonProperty]
         public float? AnchorY { get; set; }
-        [DataMember]
+        [JsonProperty]
         public float? Frametime { get; set; }
-        [DataMember]
+        [JsonProperty]
         public int? Count { get; set; }
 
+        [JsonIgnore]
         public Texture2D Texture { get; set; }
 
         public List<Frame> Solidify()
@@ -220,14 +215,14 @@ namespace Lichen.Libraries
         }
     }
 
-    [DataContract]
+    [JsonObject]
     public class _Animation
     {
-        [DataMember]
+        [JsonProperty]
         public string Name { get; set; }
-        [DataMember]
+        [JsonProperty]
         public float? Speed { get; set; }
-        [DataMember]
+        [JsonProperty]
         public List<_FrameRange> FrameRanges { get; set; }
 
         public Animation Solidify()

--- a/Source/Framework/Properties/AssemblyInfo.cs
+++ b/Source/Framework/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Lichen")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Microsoft")]
+[assembly: AssemblyProduct("Lichen")]
+[assembly: AssemblyCopyright("Copyright © Microsoft 2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("08e18633-f54f-4cff-9d9d-7bcbebec546f")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Source/Framework/Util/JsonHelper.cs
+++ b/Source/Framework/Util/JsonHelper.cs
@@ -1,8 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Newtonsoft.Json;
 using System.IO;
-using System.Runtime.Serialization.Json;
 using System.Text;
+using System.Runtime.Serialization.Json;
+using System;
+using System.Collections.Generic;
 using System.Xml.Linq;
 
 namespace Lichen.Util
@@ -12,6 +13,16 @@ namespace Lichen.Util
     {
         public static T Load(string path)
         {
+            
+            string json;
+            using (StreamReader streamReader = new StreamReader(path, Encoding.UTF8))
+            {
+                json = streamReader.ReadToEnd();
+            }
+            T item = JsonConvert.DeserializeObject<T>(json);
+            return item;
+            
+            /*
             byte[] json = null;
             FileStream fs = new FileStream(path, FileMode.Open);
             // TODO: Replace this unreliable byte size limit with a "file size too large" error.
@@ -27,10 +38,20 @@ namespace Lichen.Util
             ms.Close();
             T item = (T)obj;
             return item;
+            */
         }
 
         public static void Save(string path, T item)
         {
+            
+            string json;
+            json = JsonConvert.SerializeObject(item);
+            using (StreamWriter streamWriter = new StreamWriter(path, false, Encoding.UTF8))
+            {
+                streamWriter.Write(json);
+            }
+            
+            /*
             DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(T));
             MemoryStream ms = new MemoryStream();
             serializer.WriteObject(ms, item);
@@ -40,6 +61,7 @@ namespace Lichen.Util
             FileStream fs = new FileStream(path, FileMode.Create);
             // TODO: Change the way the size limit works.
             fs.Write(json, 0, Math.Min(json.Length, 32768));
+            */
         }
 
         static void RemoveComments(byte[] source, MemoryStream target)

--- a/Source/Framework/Util/JsonHelper.cs
+++ b/Source/Framework/Util/JsonHelper.cs
@@ -1,10 +1,8 @@
 ﻿using Newtonsoft.Json;
 using System.IO;
 using System.Text;
-using System.Runtime.Serialization.Json;
 using System;
 using System.Collections.Generic;
-using System.Xml.Linq;
 
 namespace Lichen.Util
 {

--- a/Source/Game/Game.csproj
+++ b/Source/Game/Game.csproj
@@ -13,7 +13,7 @@
     <AssemblyName>LifeDeath</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <MonoGamePlatform>DesktopGL</MonoGamePlatform>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
@@ -134,6 +134,7 @@
     <None Include="app.manifest" />
     <Compile Include="Scenes\MusicRoom.cs" />
   </ItemGroup>
+  <!--
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.6.1">
       <Visible>False</Visible>
@@ -146,6 +147,7 @@
       <Install>false</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  -->
   <ItemGroup>
     <ProjectReference Include="..\Framework\Framework.csproj">
       <Project>{9daaa09d-df84-4060-81fb-8d1ac7be0d55}</Project>

--- a/Source/Game/Game.csproj
+++ b/Source/Game/Game.csproj
@@ -152,6 +152,11 @@
       <Name>Framework</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>12.0.1</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildExtensionsPath)\MonoGame\v3.0\MonoGame.Content.Builder.targets" />
   <PropertyGroup>

--- a/Source/Game/app.config
+++ b/Source/Game/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/Source/thfgj3-lifedeath.sln
+++ b/Source/thfgj3-lifedeath.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 15.0.27428.2043
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Game", "Game\Game.csproj", "{AC4599EF-488F-4807-8B67-0DAAC23E9BBA}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Framework", "Framework\Framework.csproj", "{9DAAA09D-DF84-4060-81FB-8D1AC7BE0D55}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Framework", "Framework\Framework.csproj", "{C75E8EC6-FB61-4E7C-A51F-5ABB8BA3DBC4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,10 +17,10 @@ Global
 		{AC4599EF-488F-4807-8B67-0DAAC23E9BBA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AC4599EF-488F-4807-8B67-0DAAC23E9BBA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AC4599EF-488F-4807-8B67-0DAAC23E9BBA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{9DAAA09D-DF84-4060-81FB-8D1AC7BE0D55}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9DAAA09D-DF84-4060-81FB-8D1AC7BE0D55}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9DAAA09D-DF84-4060-81FB-8D1AC7BE0D55}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9DAAA09D-DF84-4060-81FB-8D1AC7BE0D55}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C75E8EC6-FB61-4E7C-A51F-5ABB8BA3DBC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C75E8EC6-FB61-4E7C-A51F-5ABB8BA3DBC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C75E8EC6-FB61-4E7C-A51F-5ABB8BA3DBC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C75E8EC6-FB61-4E7C-A51F-5ABB8BA3DBC4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- Switched from .NET Framework 4.6.1 and .NET Standard 2.0 to just using .NET Framework 4.5 (the lowest supported by MonoGame) to maximize compatibility.
- Switched from System.Runtime.Serialization.Json to Newtonsoft.Json.